### PR TITLE
fix: duplicate spans issue

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -52,8 +52,7 @@ func InitTracer() func(context.Context) error {
 
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithSampler(sdktrace.AlwaysSample()),
-		sdktrace.WithSpanProcessor(sdktrace.NewBatchSpanProcessor(exporter)),
-		sdktrace.WithSyncer(exporter),
+		sdktrace.WithBatcher(exporter),
 		sdktrace.WithResource(resources),
 	)
 	otel.SetTracerProvider(tp)


### PR DESCRIPTION
Use only batch exporter instead of using multiple exporters